### PR TITLE
Adds support for per-skill summons (for Magallan)

### DIFF
--- a/src/data/summons.json
+++ b/src/data/summons.json
@@ -5613,7 +5613,8 @@
     "cnName": "龙腾.L",
     "subProfessionId": "notchar1",
     "isCnOnly": false,
-    "fileIndex": 198
+    "fileIndex": 198,
+    "operatorName": "Magallan"
   },
   {
     "name": "Soaring Dragon A",
@@ -6807,7 +6808,8 @@
     "cnName": "龙腾.A",
     "subProfessionId": "notchar1",
     "isCnOnly": false,
-    "fileIndex": 199
+    "fileIndex": 199,
+    "operatorName": "Magallan"
   },
   {
     "name": "Cursed Doll",

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -209,6 +209,10 @@ const OperatorAnalysis: React.VFC<Props> = (props) => {
   ]
     .filter((html) => !!html)
     .map((html, i) => {
+      // if this operator has per-skill summons, then pass the correct summon for this skill
+      if (summons.length > 1) {
+        context.summon = summons[i];
+      }
       if (skillRecommended[i]) {
         return (
           <Fragment>

--- a/src/scripts/gamedata-types.ts
+++ b/src/scripts/gamedata-types.ts
@@ -1,0 +1,31 @@
+export interface Character {
+  name: string;
+  description: string;
+  appellation: string;
+  profession: string;
+  phases: {
+    rangeId: string | null;
+    [otherProperties: string]: unknown;
+  }[];
+  talents:
+    | {
+        candidates: {
+          rangeId: string | null;
+          name: string;
+          description: string;
+        }[];
+      }[]
+    | null;
+  tokenKey: string | null;
+  skills: {
+    skillId: string | null;
+    rangeId: string | null;
+    overrideTokenKey: string | null;
+  }[];
+}
+
+export interface SkillAtLevel {
+  name: string;
+  description: string;
+  rangeId: string | null;
+}


### PR DESCRIPTION
Magallan has a default `tokenKey` (her skill 1 summon), but has two other summons specified by `overrideTokenKey` in her `skills` array.

We link `overrideTokenKey` values to their operator, then pull all summons matching the current operator's name. In the event there is more than 1, we replace the `context.summon` value depending on the skill index.