### PR TITLE
add nicer headers

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -31,7 +31,6 @@ const styles = (theme: Theme) => css`
 
   .heading-block {
     padding: ${theme.spacing(2, 0, 2, 4)};
-    background-color: ${transparentize(0.34, theme.palette.midtoneDarker)};
     border-top-right-radius: ${theme.spacing(1)};
 
     ${theme.breakpoints.down("mobile")} {

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -401,7 +401,6 @@ const globalOverrideStyles =
       
       .heading-block {
         background: linear-gradient(90deg, ${transparentize(0.9, accentColor)}, transparent), ${transparentize(0.67, theme.palette.midtoneBrighter)};
-        backdrop-filter: blur(${theme.spacing(1)});
       }
 
       header {

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -400,8 +400,8 @@ const globalOverrideStyles =
       }
       
       .heading-block {
-        background: linear-gradient(90deg, ${transparentize(0.9, accentColor)}, ${transparentize(1, theme.palette.white)}), ${transparentize(0.67, theme.palette.midtoneBrighter)};
-        backdrop-filter: blur(8px);
+        background: linear-gradient(90deg, ${transparentize(0.9, accentColor)}, transparent), ${transparentize(0.67, theme.palette.midtoneBrighter)};
+        backdrop-filter: blur(${theme.spacing(1)});
       }
 
       header {

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -398,6 +398,11 @@ const globalOverrideStyles =
       a {
         color: ${accentColor};
       }
+      
+      .heading-block {
+        background: linear-gradient(90deg, ${transparentize(0.9, accentColor)}, ${transparentize(1, theme.palette.white)}), ${transparentize(0.67, theme.palette.midtoneBrighter)};
+        backdrop-filter: blur(8px);
+      }
 
       header {
         .heading-and-breadcrumb {


### PR DESCRIPTION
This changes the header on each page for specific operator guides.

Note: `backdrop-filter` has bad browser support and doesn't work on Firefox, but without the blur, it still looks okay, and namtar wanted to use it.

We will ideally add more header changes here in the future... but for now we have more important things to do.