### PR TITLE
T-62 Add aceship.json file for Aceship integration

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
     },
     "gatsby-theme-material-ui",
     "gatsby-plugin-react-helmet",
+    "gatsby-plugin-aceship",
     {
       resolve: "gatsby-plugin-sitemap",
       options: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
 [[headers]]
   for = "/aceship.json"
   [headers.values]
-    Access-Control-Allow-Origin: "*"
+    Access-Control-Allow-Origin = "*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@
   to = "/operators/"
   status = 302
   force = true
+
+[[headers]]
+  for = "/aceship.json"
+  [headers.values]
+    Access-Control-Allow-Origin: "*"

--- a/plugins/gatsby-plugin-aceship/gatsby-node.js
+++ b/plugins/gatsby-plugin-aceship/gatsby-node.js
@@ -20,7 +20,7 @@ exports.onCreatePage = ({ page, reporter }) => {
   }
 }
 
-exports.onPostBootstrap = ({ reporter }) => {
+exports.onPostBuild = ({ reporter }) => {
   reporter.verbose(`Generated Aceship opId to path json: ${JSON.stringify(opIdToPath, null, 2)}`);
   fs.writeFileSync(path.join('public', OUTFILE_NAME), JSON.stringify(opIdToPath));
   reporter.info(`Aceship plugin: wrote ${Object.keys(opIdToPath).length} entries to public/${OUTFILE_NAME}`);

--- a/plugins/gatsby-plugin-aceship/gatsby-node.js
+++ b/plugins/gatsby-plugin-aceship/gatsby-node.js
@@ -4,11 +4,17 @@ const opNameToId = Object.fromEntries(operatorsJson.map((op) => [op.name, op.id]
 const opIdToPath = {};
 
 exports.onCreatePage = ({ page, reporter, actions }) => {
-  if (page.context?.operator__name) {
-    opIdToPath[opNameToId[page.context.operator__name]] = page.path;
+  const opName = page.context?.operator__name;
+  if (opName) {
+    const opId = opNameToId[opName];
+    if (!opId) {
+      reporter.panic(`Couldn't find id for operator name "${opName}"`);
+    } else {
+      opIdToPath[opId] = page.path;
+    }
   }
 }
 
 exports.onPostBootstrap = () => {
-  console.table(opIdToPath);
+  reporter.verbose(`Generated Aceship opId to path json: ${JSON.stringify(opIdToPath, null, 2)}`);
 }

--- a/plugins/gatsby-plugin-aceship/gatsby-node.js
+++ b/plugins/gatsby-plugin-aceship/gatsby-node.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+const operatorsJson = require("../../src/data/operators.json");
+const opNameToId = Object.fromEntries(operatorsJson.map((op) => [op.name, op.id]));
+const opIdToPath = {};
+
+exports.onCreatePage = ({ page, reporter, actions }) => {
+  if (page.context?.operator__name) {
+    opIdToPath[opNameToId[page.context.operator__name]] = page.path;
+  }
+}
+
+exports.onPostBootstrap = () => {
+  console.table(opIdToPath);
+}

--- a/plugins/gatsby-plugin-aceship/gatsby-node.js
+++ b/plugins/gatsby-plugin-aceship/gatsby-node.js
@@ -1,9 +1,14 @@
 /* eslint-disable */
 const operatorsJson = require("../../src/data/operators.json");
+const path = require("path");
+const fs = require("fs");
+
+const OUTFILE_NAME = "aceship.json";
+
 const opNameToId = Object.fromEntries(operatorsJson.map((op) => [op.name, op.id]));
 const opIdToPath = {};
 
-exports.onCreatePage = ({ page, reporter, actions }) => {
+exports.onCreatePage = ({ page, reporter }) => {
   const opName = page.context?.operator__name;
   if (opName) {
     const opId = opNameToId[opName];
@@ -15,6 +20,8 @@ exports.onCreatePage = ({ page, reporter, actions }) => {
   }
 }
 
-exports.onPostBootstrap = () => {
+exports.onPostBootstrap = ({ reporter }) => {
   reporter.verbose(`Generated Aceship opId to path json: ${JSON.stringify(opIdToPath, null, 2)}`);
+  fs.writeFileSync(path.join('public', OUTFILE_NAME), JSON.stringify(opIdToPath));
+  reporter.info(`Aceship plugin: wrote ${Object.keys(opIdToPath).length} entries to public/${OUTFILE_NAME}`);
 }

--- a/plugins/gatsby-plugin-aceship/package.json
+++ b/plugins/gatsby-plugin-aceship/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatsby-plugin-aceship",
+  "version": "1.0.0",
+  "description": "Produces a mapping of operator IDs to page URLs for Aceship's Arknights site",
+  "main": "index.js",
+  "author": "Ian Kim",
+  "license": "GPL-2.0-or-later"
+}


### PR DESCRIPTION
This adds a local plugin `gatsby-plugin-aceship` that emits an `aceship.json` file to the `public/` directory. It has the form
```ts
{ [operatorId: string]: <relativeUrl>; }
```
This way Ace doesn't have to manually update the set of operators that have SG guides.