### PR TITLE
Fix damage type determination for when description is in CN

### DIFF
--- a/src/components/OperatorInfo.tsx
+++ b/src/components/OperatorInfo.tsx
@@ -24,7 +24,8 @@ const getAttackType = (
 ): "Physical" | "Arts" | "Healing" | "None" => {
   if (subProfessionId === "bard") return "None";
   if (operatorClass === "Medic") return "Healing";
-  return description.toLowerCase().includes("arts damage")
+  return description.toLowerCase().includes("arts damage") ||
+    description.includes("法术伤害")
     ? "Arts"
     : "Physical";
 };


### PR DESCRIPTION
This fixes Corroserum's attack type showing up as "Physical", when he actually deals Arts.