### PR TITLE
Fix vertical text alignment for operator card hover state

### DIFF
--- a/src/pages/operators/index.tsx
+++ b/src/pages/operators/index.tsx
@@ -926,7 +926,8 @@ const styles = (theme: Theme) => css`
               padding: ${theme.spacing(2)};
               display: grid;
               grid-template-columns: max-content 1fr max-content;
-              align-items: flex-end;
+              align-items: center;
+              align-content: flex-end;
               border-radius: ${theme.spacing(0, 0, 0.5, 0.5)};
 
               .go-to-guide-icon {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1508774/144099449-1023bba0-25c3-4ba5-a8c7-e2c1d6bb3c7b.png)

After this PR:
<img width="196" alt="Screen Shot 2021-11-30 at 12 41 03 PM" src="https://user-images.githubusercontent.com/1508774/144099414-13fefca1-a81b-4981-8aa8-cdab2cb65442.png">
