### PR TITLE
Explicitly set padding: 0 for card buttons

### DIFF
--- a/src/components/CardWithTabs.tsx
+++ b/src/components/CardWithTabs.tsx
@@ -119,6 +119,7 @@ const styles = (theme: Theme) => css`
         box-sizing: border-box;
         border: ${theme.spacing(0.25)} solid
           ${theme.palette.midtoneBrighter.main};
+        padding: 0;
         margin-bottom: ${theme.spacing(2)};
         display: flex;
         align-items: center;


### PR DESCRIPTION
iOS Safari for some reason will put padding on <button> (but not Mac Safari!) and as a result the "III" icon does not fit inside the width: 48px button.