### PR TITLE
T-81 Don't show focus indicators when using a mouse

### DIFF
--- a/src/components/CustomCheckbox.tsx
+++ b/src/components/CustomCheckbox.tsx
@@ -72,7 +72,7 @@ const styles = (theme: Theme) => css`
       background-color: ${theme.palette.blue.main};
     }
 
-    input:focus + .checkbox-control {
+    input:focus-visible + .checkbox-control {
       box-shadow: 0 0 0 0.05em #fff, 0 0 0.15em 0.1em ${theme.palette.blue.main};
     }
   }

--- a/src/components/TabPanels.tsx
+++ b/src/components/TabPanels.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import { css } from "@mui/material";
 
 export type TabPanelsProps = React.HTMLAttributes<HTMLDivElement> &
   Partial<{
@@ -24,7 +25,7 @@ const TabPanels: React.FC<TabPanelsProps> = (props) => {
   }, [activeTab, userActed]);
 
   return (
-    <div {...rest} ref={panelsRef}>
+    <div css={styles} {...rest} ref={panelsRef}>
       {React.Children.map(panelChildren, (child, i) => {
         const isActiveTab = i === activeTab;
         return React.cloneElement<
@@ -40,3 +41,11 @@ const TabPanels: React.FC<TabPanelsProps> = (props) => {
   );
 };
 export default TabPanels;
+
+const styles = css`
+  & > * {
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
+  }
+`;

--- a/src/components/TabPanels.tsx
+++ b/src/components/TabPanels.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { css } from "@mui/material";
+import { css, Theme } from "@mui/material";
 
 export type TabPanelsProps = React.HTMLAttributes<HTMLDivElement> &
   Partial<{
@@ -42,10 +42,16 @@ const TabPanels: React.FC<TabPanelsProps> = (props) => {
 };
 export default TabPanels;
 
-const styles = css`
+const styles = (theme: Theme) => css`
   & > * {
     &:focus:not(:focus-visible) {
       outline: none;
+    }
+
+    ${theme.breakpoints.down("maxWidth")} {
+      &:focus {
+        outline: none;
+      }
     }
   }
 `;


### PR DESCRIPTION
This fixes two cases of focus indicators showing for mouse users when they should only show for keyboard focus events:
- Checkbox focus highlight
- Mobile highlight for tab panels

It does *not* fix
- Slider thumb focus highlight
because that seems to be an upstream MUI issue; it's been reported already.