### PR TITLE
Use @artsy/fresnel for combined mobile & desktop SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "update-game-data": "git submodule update --init --recursive --remote && ts-node-script ./src/scripts/copy-gamedata.ts"
   },
   "dependencies": {
+    "@artsy/fresnel": "^3.2.1",
     "@emotion/babel-plugin": "^11.3.0",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.3.2",
-    "typescript": "^4.3.5"
+    "raw-loader": "^4.0.2",
+    "sharp": "^0.26.0",
+    "typescript": "^4.3.5",
+    "webpack": "^5.0.0"
   },
   "engines": {
     "node": ">=16"

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from "react";
 import { graphql, useStaticQuery } from "gatsby";
-import { Theme, useMediaQuery } from "@mui/material";
+import { Theme } from "@mui/material";
 import { css, Global } from "@emotion/react";
 import { Helmet } from "react-helmet";
 import { BsDiscord as DiscordLogo } from "react-icons/bs";
@@ -12,7 +12,7 @@ import { lighten, rgba, transparentize } from "polished";
 import MobileMenu from "./components/MobileMenu";
 import SearchBar from "./components/SearchBar";
 import WeirdDeathSphere from "./components/WeirdDeathSphere";
-import theme from "./gatsby-theme-material-ui-top-layout/theme";
+import { Media } from "./Media";
 
 interface LayoutProps {
   pageTitle: string;
@@ -69,7 +69,6 @@ const Layout: React.FC<LayoutProps> = (props) => {
   } = data.site.siteMetadata;
 
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
 
   const title = pageTitle
     ? `${pageTitle} / Arknights Hub - ${siteName}`
@@ -157,8 +156,8 @@ const Layout: React.FC<LayoutProps> = (props) => {
             <header>
               <div className="heading-and-breadcrumb">
                 <div className="heading-spacer" />
-                {!isMobile && previousLocation && previousLocationLink && (
-                  <div className="breadcrumb">
+                {previousLocation && previousLocationLink && (
+                  <Media greaterThanOrEqual="mobile" className="breadcrumb">
                     <a
                       href={previousLocationLink}
                       aria-label={`Back to ${previousLocation}`}
@@ -166,7 +165,7 @@ const Layout: React.FC<LayoutProps> = (props) => {
                       {previousLocation}
                     </a>
                     /
-                  </div>
+                  </Media>
                 )}
                 {customPageHeading || <h1>{pageTitle}</h1>}
               </div>

--- a/src/Media.ts
+++ b/src/Media.ts
@@ -1,0 +1,9 @@
+import { createMedia } from "@artsy/fresnel";
+import { customBreakpoints } from "./gatsby-theme-material-ui-top-layout/theme";
+
+const AppMedia = createMedia({
+  breakpoints: customBreakpoints,
+});
+
+export const mediaStyle = AppMedia.createMediaStyle();
+export const { Media, MediaContextProvider } = AppMedia;

--- a/src/Media.ts
+++ b/src/Media.ts
@@ -2,7 +2,10 @@ import { createMedia } from "@artsy/fresnel";
 import { customBreakpoints } from "./gatsby-theme-material-ui-top-layout/theme";
 
 const AppMedia = createMedia({
-  breakpoints: customBreakpoints,
+  breakpoints: {
+    base: 0,
+    ...customBreakpoints,
+  },
 });
 
 export const mediaStyle = AppMedia.createMediaStyle();

--- a/src/components/OperatorInfo.tsx
+++ b/src/components/OperatorInfo.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Theme, Tooltip } from "@mui/material";
+import { useMediaQuery, useTheme, Theme, Tooltip } from "@mui/material";
 import { Fragment } from "react";
 import { Media } from "../Media";
 
@@ -54,6 +54,8 @@ const OperatorInfo: React.VFC<OperatorInfoProps> = (props) => {
     subProfessionId,
     description
   );
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
   const [charName, alterName] = name.split(" the ");
 
   return (
@@ -109,10 +111,9 @@ const OperatorInfo: React.VFC<OperatorInfoProps> = (props) => {
           <dt>Regular Attack</dt>
           <dd className={slugify(attackType)}>
             {attackType}
-            <Media greaterThanOrEqual="mobile">
-              {(attackType === "Arts" || attackType === "Physical") &&
-                " Damage"}
-            </Media>
+            {!isMobile &&
+              (attackType === "Arts" || attackType === "Physical") &&
+              " Damage"}
           </dd>
         </div>
 

--- a/src/components/OperatorInfo.tsx
+++ b/src/components/OperatorInfo.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
-import { useMediaQuery, useTheme, Theme, Tooltip } from "@mui/material";
+import { Theme, Tooltip } from "@mui/material";
 import { Fragment } from "react";
+import { Media } from "../Media";
 
 import {
   professionToClass,
@@ -53,8 +54,6 @@ const OperatorInfo: React.VFC<OperatorInfoProps> = (props) => {
     subProfessionId,
     description
   );
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
   const [charName, alterName] = name.split(" the ");
 
   return (
@@ -93,21 +92,27 @@ const OperatorInfo: React.VFC<OperatorInfoProps> = (props) => {
             </span>
           </a>
         </div>
-        <OperatorPortrait
-          variant={isMobile ? "small" : "normal"}
-          name={name}
-          isLimited={isLimited}
-          rarity={rarity}
-        />
+        <Media lessThan="mobile">
+          <OperatorPortrait
+            variant="small"
+            name={name}
+            isLimited={isLimited}
+            rarity={rarity}
+          />
+        </Media>
+        <Media greaterThanOrEqual="mobile">
+          <OperatorPortrait name={name} isLimited={isLimited} rarity={rarity} />
+        </Media>
       </div>
       <dl className="attack-type-and-position">
         <div className="attack-type">
           <dt>Regular Attack</dt>
           <dd className={slugify(attackType)}>
             {attackType}
-            {!isMobile &&
-              (attackType === "Arts" || attackType === "Physical") &&
-              " Damage"}
+            <Media greaterThanOrEqual="mobile">
+              {(attackType === "Arts" || attackType === "Physical") &&
+                " Damage"}
+            </Media>
           </dd>
         </div>
 

--- a/src/components/TabButtons.tsx
+++ b/src/components/TabButtons.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment } from "react";
 import { css } from "@emotion/react";
 import ScrollContainer from "react-indiana-drag-scroll";
-import { useMediaQuery, useTheme } from "@mui/material";
 
 import { Media } from "../Media";
 
@@ -17,9 +16,6 @@ export type TabButtonsProps = Omit<
 
 const TabButtons: React.FC<TabButtonsProps> = (props) => {
   const { activeTab, onClick, isSwiper, children, ...rest } = props;
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
-
   const buttonChildren = React.Children.toArray(children).filter(
     (child) =>
       React.isValidElement<React.HTMLAttributes<HTMLButtonElement>>(child) &&

--- a/src/components/TabButtons.tsx
+++ b/src/components/TabButtons.tsx
@@ -3,6 +3,8 @@ import { css } from "@emotion/react";
 import ScrollContainer from "react-indiana-drag-scroll";
 import { useMediaQuery, useTheme } from "@mui/material";
 
+import { Media } from "../Media";
+
 export type TabButtonsProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "onClick"
@@ -93,25 +95,26 @@ const TabButtons: React.FC<TabButtonsProps> = (props) => {
     }
   }
 
-  return (
+  return isSwiper ? (
     <Fragment>
-      <div
-        role="tablist"
-        {...rest}
-        {...(isSwiper && isMobile ? { style: { display: "none" } } : {})}
-      >
-        {newChildren}
-      </div>
-      {isSwiper && (
+      <Media lessThan="mobile">
         <ScrollContainer
           css={swiperStyles}
           className="tab-buttons swiper-container"
-          style={!isMobile ? { display: "none" } : {}}
         >
           {newChildren}
         </ScrollContainer>
-      )}
+      </Media>
+      <Media greaterThanOrEqual="mobile">
+        <div role="tablist" {...rest}>
+          {newChildren}
+        </div>
+      </Media>
     </Fragment>
+  ) : (
+    <div role="tablist" {...rest}>
+      {newChildren}
+    </div>
   );
 };
 export default TabButtons;

--- a/src/gatsby-theme-material-ui-top-layout/components/top-layout.tsx
+++ b/src/gatsby-theme-material-ui-top-layout/components/top-layout.tsx
@@ -2,6 +2,8 @@ import { Theme, ThemeProvider as MuiThemeProvider } from "@mui/material";
 import { ThemeProvider as EmotionThemeProvider, Global } from "@emotion/react";
 import emotionNormalize from "emotion-normalize";
 
+import { MediaContextProvider, mediaStyle } from "../../Media";
+
 export default function TopLayout({
   children,
   theme,
@@ -10,11 +12,14 @@ export default function TopLayout({
   theme: Theme;
 }): React.ReactElement {
   return (
-    <MuiThemeProvider theme={theme}>
-      <EmotionThemeProvider theme={theme}>
-        <Global styles={emotionNormalize} />
-        {children}
-      </EmotionThemeProvider>
-    </MuiThemeProvider>
+    <MediaContextProvider>
+      <MuiThemeProvider theme={theme}>
+        <EmotionThemeProvider theme={theme}>
+          <Global styles={emotionNormalize} />
+          <Global styles={mediaStyle} />
+          {children}
+        </EmotionThemeProvider>
+      </MuiThemeProvider>
+    </MediaContextProvider>
   );
 }

--- a/src/gatsby-theme-material-ui-top-layout/theme.ts
+++ b/src/gatsby-theme-material-ui-top-layout/theme.ts
@@ -111,6 +111,11 @@ declare module "@mui/material/Button" {
 
 const spacingUnit = 8;
 
+export const customBreakpoints = {
+  mobile: 1000,
+  maxWidth: 1270 + spacingUnit * 3 * 2,
+};
+
 const baseTheme = createTheme({
   spacing: spacingUnit,
   palette: {
@@ -260,10 +265,7 @@ const baseTheme = createTheme({
     },
   },
   breakpoints: {
-    values: {
-      mobile: 1000,
-      maxWidth: 1270 + spacingUnit * 3 * 2,
-    },
+    values: customBreakpoints,
   },
 } as ThemeOptions);
 

--- a/src/pages/operators/index.tsx
+++ b/src/pages/operators/index.tsx
@@ -16,7 +16,6 @@ import {
   MenuItem,
   styled,
   Theme,
-  useMediaQuery,
   useTheme,
 } from "@mui/material";
 import slugify from "@sindresorhus/slugify";
@@ -42,6 +41,7 @@ import FilterIcon from "../../components/icons/FilterIcon";
 import HorizontalScroller from "../../components/HorizontalScroller";
 import OperatorList from "../../components/OperatorList";
 import TraitInfo from "../../components/TraitInfo";
+import { Media } from "../../Media";
 
 const MENU_ICON_SIZE = 18;
 
@@ -139,7 +139,6 @@ const Operators: React.VFC<Props> = ({ data }) => {
     string | null
   >(null);
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -363,7 +362,9 @@ const Operators: React.VFC<Props> = ({ data }) => {
             </ClassSubclassMenuItem>
           ))}
       </Menu>
-      {!isMobile && <div className="spacer" />}
+      <Media lessThan="mobile">
+        <div className="spacer" />
+      </Media>
       <CustomCheckbox
         label="Guide available"
         onChange={handleGuideAvailableChange}
@@ -393,15 +394,16 @@ const Operators: React.VFC<Props> = ({ data }) => {
               .toLocaleString(DateTime.DATE_FULL)}
           </span>
         </span> */}
-          {isMobile ? (
+          <Media lessThan="mobile">
             <HorizontalScroller className="sort-and-filter-options">
               {sortAndFilterOptions}
             </HorizontalScroller>
-          ) : (
+          </Media>
+          <Media greaterThanOrEqual="mobile">
             <div className="sort-and-filter-options">
               {sortAndFilterOptions}
             </div>
-          )}
+          </Media>
 
           {selectedProfession != null && (
             <div className="toggle-button-container">

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -479,7 +479,11 @@ const styles = (accentColor: string) => (theme: Theme) =>
       grid-template-columns: 1fr;
     }
 
-    .tabs ~ .swiper-container {
+    .fresnel-container {
+      display: grid;
+    }
+
+    .fresnel-container > .swiper-container {
       background-color: ${transparentize(0.34, theme.palette.dark.main)};
       backdrop-filter: blur(8px);
 
@@ -523,7 +527,7 @@ const styles = (accentColor: string) => (theme: Theme) =>
       }
     }
 
-    & > .tabs {
+    .fresnel-container > .tabs {
       display: flex;
       flex-direction: column;
       z-index: 1;

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { css, Global } from "@emotion/react";
-import { Theme, useMediaQuery, useTheme } from "@mui/material";
+import { Theme, useTheme } from "@mui/material";
 import { graphql } from "gatsby";
 import { lighten, rgba, transparentize } from "polished";
 import { DateTime } from "luxon";
@@ -23,6 +23,7 @@ import CardWithTabs from "../../components/CardWithTabs";
 import { CharacterObject } from "../../utils/types";
 import MasteryRecommendation from "../../components/MasteryRecommendation";
 import { operatorImage } from "../../utils/images";
+import { Media } from "../../Media";
 
 interface HTMLToReactContext {
   skills: SkillObject[];
@@ -198,7 +199,6 @@ const OperatorAnalysis: React.VFC<Props> = (props) => {
     summon: summons.length > 0 ? summons[0] : undefined,
   };
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("mobile"));
 
   const talentAnalyses = [
     contentful.talent1Analysis.childMarkdownRemark.html,
@@ -354,7 +354,9 @@ const OperatorAnalysis: React.VFC<Props> = (props) => {
           ))}
         </TabPanels>
         <div className="left-sidebar">
-          {!isMobile && <hr />}
+          <Media lessThan="mobile">
+            <hr />
+          </Media>
           <div className="external-links">
             <span className="section-label">External Links</span>
             <a

--- a/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
+++ b/src/pages/operators/{contentfulOperatorAnalysis.operator__name}.tsx
@@ -354,7 +354,7 @@ const OperatorAnalysis: React.VFC<Props> = (props) => {
           ))}
         </TabPanels>
         <div className="left-sidebar">
-          <Media lessThan="mobile">
+          <Media greaterThanOrEqual="mobile">
             <hr />
           </Media>
           <div className="external-links">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4863,6 +4863,11 @@ array-flatten@^2.1.0:
   resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
+array-flatten@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
+  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
+
 array-includes@^3.0.3, array-includes@^3.1.1, array-includes@^3.1.2, array-includes@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
@@ -6222,7 +6227,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -6253,6 +6258,14 @@ color-string@^1.6.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 color@^4.0.1:
   version "4.0.1"
@@ -13372,6 +13385,11 @@ node-abi@^2.21.0:
   dependencies:
     semver "^5.4.1"
 
+node-addon-api@^3.0.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-addon-api@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.2.0.tgz#117cbb5a959dff0992e1c586ae0393573e4d2a87"
@@ -14824,7 +14842,7 @@ potrace@^2.1.8:
   dependencies:
     jimp "^0.14.0"
 
-prebuild-install@^6.1.4:
+prebuild-install@^6.0.0, prebuild-install@^6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
   integrity sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
@@ -15234,7 +15252,7 @@ raw-body@^2.4.1:
 
 raw-loader@^4.0.2:
   version "4.0.2"
-  resolved "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
   integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
   dependencies:
     loader-utils "^2.0.0"
@@ -16445,6 +16463,22 @@ shallowequal@^1.1.0:
   resolved "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
+sharp@^0.26.0:
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.26.3.tgz#9de8577a986b22538e6e12ced1f7e8a53f9728de"
+  integrity sha512-NdEJ9S6AMr8Px0zgtFo1TJjMK/ROMU92MkDtYn2BBrDjIx3YfH9TUyGdzPC+I/L619GeYQc690Vbaxc5FPCCWg==
+  dependencies:
+    array-flatten "^3.0.0"
+    color "^3.1.3"
+    detect-libc "^1.0.3"
+    node-addon-api "^3.0.2"
+    npmlog "^4.1.2"
+    prebuild-install "^6.0.0"
+    semver "^7.3.2"
+    simple-get "^4.0.0"
+    tar-fs "^2.1.1"
+    tunnel-agent "^0.6.0"
+
 sharp@^0.29.0:
   version "0.29.2"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.29.2.tgz#e8c003cd9cb321585b32dbda6eed3baa7d6f2308"
@@ -16513,6 +16547,15 @@ simple-get@^3.0.3, simple-get@^3.1.0:
   integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.0.tgz#73fa628278d21de83dadd5512d2cc1f4872bd675"
+  integrity sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -18490,6 +18533,14 @@ watchpack@^2.2.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25"
+  integrity sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -18616,6 +18667,11 @@ webpack-sources@^3.2.0:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
   integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
 
+webpack-sources@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
+  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+
 webpack-stats-plugin@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.0.3.tgz#0f64551a0b984b48a9e7acdee32e3cfda556fe51"
@@ -18668,6 +18724,36 @@ webpack@4:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.0.0:
+  version "5.65.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.65.0.tgz#ed2891d9145ba1f0d318e4ea4f89c3fa18e6f9be"
+  integrity sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.3.1"
+    webpack-sources "^3.2.2"
 
 webpack@^5.35.0:
   version "5.46.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,11 @@
   dependencies:
     tslib "~2.0.1"
 
+"@artsy/fresnel@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-3.2.1.tgz#920f5fae518d1af622e790ee02235b52e62a045d"
+  integrity sha512-08mn27qkJzJu7O4CwjxH2KTix7jvbl0gRtgxjjUYTk7o2LAOHOgv3lnEV77tOc06khSV0GWTgGFUzG7cfDSwzQ==
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"


### PR DESCRIPTION
Right now we only SSR the desktop layout (because the default viewport is assumed to be desktop). That causes layout shift on mobile because the browser tears down the desktop-only components and renders mobile-only components at hydration time.

This approach SSRs both mobile-only and desktop-only components, uses CSS to hide one, then tears down one of them at hydration time.