### PR TITLE
Re-add Google Analytics tracking code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 CONTENTFUL_SPACE_ID=9auzhr5vyq9m
 CONTENTFUL_ACCESS_TOKEN=<access token for contentful>
+GOOGLE_ANALYTICS_TRACKING_ID=<google analytics ID>

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 CONTENTFUL_SPACE_ID=9auzhr5vyq9m
 CONTENTFUL_ACCESS_TOKEN=<access token for contentful>
-GOOGLE_ANALYTICS_TRACKING_ID=<google analytics ID>
+NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=<google analytics ID>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@storybook/testing-library": "^0.0.9",
     "@storybook/theming": "^6.4.9",
     "@types/flexsearch": "^0.7.2",
+    "@types/gtag.js": "^0.0.8",
     "@types/js-levenshtein": "^1.1.1",
     "@types/luxon": "^2.0.9",
     "@types/node": "^17.0.18",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { MediaContextProvider, mediaStyle } from "../Media";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
-import { GA_TRACKING_ID, pageview } from "../utils/gtag";
+import { GOOGLE_ANALYTICS_TRACKING_ID, pageview } from "../utils/gtag";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
@@ -65,7 +65,7 @@ export default function MyApp(props: MyAppProps) {
               <>
                 <Script
                   strategy="afterInteractive"
-                  src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+                  src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TRACKING_ID}`}
                 />
                 <Script
                   id="gtag-init"
@@ -75,7 +75,7 @@ export default function MyApp(props: MyAppProps) {
                   window.dataLayer = window.dataLayer || [];
                   function gtag(){dataLayer.push(arguments);}
                   gtag('js', new Date());
-                  gtag('config', '${GA_TRACKING_ID}', {
+                  gtag('config', '${GOOGLE_ANALYTICS_TRACKING_ID}', {
                     page_path: window.location.pathname,
                   });
                 `,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -31,12 +31,17 @@ export default function MyApp(props: MyAppProps) {
   const router = useRouter();
 
   useEffect(() => {
-    const handleRouteChange = (url: URL) => {
-      pageview(url);
-    };
-    router.events.on("routeChangeComplete", handleRouteChange);
+    let handleRouteChange: ((url: URL) => void) | null = null;
+    if (isProductionEnvironment) {
+      handleRouteChange = (url: URL) => {
+        pageview(url);
+      };
+      router.events.on("routeChangeComplete", handleRouteChange);
+    }
     return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
+      if (handleRouteChange != null) {
+        router.events.off("routeChangeComplete", handleRouteChange);
+      }
     };
   }, [router.events]);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { MediaContextProvider, mediaStyle } from "../Media";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
-import { GOOGLE_ANALYTICS_TRACKING_ID, pageview } from "../utils/gtag";
+import { NEXT_PUBLIC_GOOGLE_ANALYTICS_ID, pageview } from "../utils/gtag";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
@@ -65,7 +65,7 @@ export default function MyApp(props: MyAppProps) {
               <>
                 <Script
                   strategy="afterInteractive"
-                  src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TRACKING_ID}`}
+                  src={`https://www.googletagmanager.com/gtag/js?id=${NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}`}
                 />
                 <Script
                   id="gtag-init"
@@ -75,7 +75,7 @@ export default function MyApp(props: MyAppProps) {
                   window.dataLayer = window.dataLayer || [];
                   function gtag(){dataLayer.push(arguments);}
                   gtag('js', new Date());
-                  gtag('config', '${GOOGLE_ANALYTICS_TRACKING_ID}', {
+                  gtag('config', '${NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}', {
                     page_path: window.location.pathname,
                   });
                 `,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,9 +9,13 @@ import { MediaContextProvider, mediaStyle } from "../Media";
 
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import Script from "next/script";
+import { GA_TRACKING_ID, pageview } from "../utils/gtag";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
+
+const isProductionEnvironment = process.env.NODE_ENV === "production";
 
 interface MyAppProps extends AppProps {
   emotionCache?: EmotionCache;
@@ -32,6 +36,31 @@ export default function MyApp(props: MyAppProps) {
                 content="initial-scale=1, width=device-width"
               />
             </Head>
+
+            {/* Global Site Tag (gtag.js) - Google Analytics */}
+            {/* from https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/_app.js */}
+            {isProductionEnvironment && (
+              <>
+                <Script
+                  strategy="afterInteractive"
+                  src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+                />
+                <Script
+                  id="gtag-init"
+                  strategy="afterInteractive"
+                  dangerouslySetInnerHTML={{
+                    __html: `
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('config', '${GA_TRACKING_ID}', {
+                    page_path: window.location.pathname,
+                  });
+                `,
+                  }}
+                />
+              </>
+            )}
 
             <Component {...pageProps} />
           </EmotionThemeProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,8 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
 import { GA_TRACKING_ID, pageview } from "../utils/gtag";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -23,6 +25,21 @@ interface MyAppProps extends AppProps {
 
 export default function MyApp(props: MyAppProps) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
+
+  // pass route change events to Google Analytics
+  // from https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/_app.js
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url: URL) => {
+      pageview(url);
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <MediaContextProvider>
       <CacheProvider value={emotionCache}>

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -1,8 +1,9 @@
 // taken mostly verbatim from https://stackoverflow.com/a/65081431/821285
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-export const GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID!;
+export const GOOGLE_ANALYTICS_TRACKING_ID =
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  process.env.GOOGLE_ANALYTICS_TRACKING_ID!;
 const isProduction = process.env.NODE_ENV === "production";
-if (isProduction && GA_TRACKING_ID == null) {
+if (isProduction && GOOGLE_ANALYTICS_TRACKING_ID == null) {
   throw new Error(
     "GOOGLE_ANALYTICS_TRACKING_ID is not set in a production environment"
   );
@@ -10,7 +11,7 @@ if (isProduction && GA_TRACKING_ID == null) {
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url: URL): void => {
-  window.gtag("config", GA_TRACKING_ID, {
+  window.gtag("config", GOOGLE_ANALYTICS_TRACKING_ID, {
     page_path: url,
   });
 };

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -1,17 +1,17 @@
 // taken mostly verbatim from https://stackoverflow.com/a/65081431/821285
-export const GOOGLE_ANALYTICS_TRACKING_ID =
+export const NEXT_PUBLIC_GOOGLE_ANALYTICS_ID =
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  process.env.GOOGLE_ANALYTICS_TRACKING_ID!;
+  process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID!;
 const isProductionEnvironment = process.env.NODE_ENV === "production";
-if (isProductionEnvironment && GOOGLE_ANALYTICS_TRACKING_ID == null) {
+if (isProductionEnvironment && NEXT_PUBLIC_GOOGLE_ANALYTICS_ID == null) {
   throw new Error(
-    "GOOGLE_ANALYTICS_TRACKING_ID is not set in a production environment"
+    "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID is not set in a production environment"
   );
 }
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url: URL): void => {
-  window.gtag("config", GOOGLE_ANALYTICS_TRACKING_ID, {
+  window.gtag("config", NEXT_PUBLIC_GOOGLE_ANALYTICS_ID, {
     page_path: url,
   });
 };

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -2,8 +2,8 @@
 export const GOOGLE_ANALYTICS_TRACKING_ID =
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   process.env.GOOGLE_ANALYTICS_TRACKING_ID!;
-const isProduction = process.env.NODE_ENV === "production";
-if (isProduction && GOOGLE_ANALYTICS_TRACKING_ID == null) {
+const isProductionEnvironment = process.env.NODE_ENV === "production";
+if (isProductionEnvironment && GOOGLE_ANALYTICS_TRACKING_ID == null) {
   throw new Error(
     "GOOGLE_ANALYTICS_TRACKING_ID is not set in a production environment"
   );

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -1,0 +1,32 @@
+// taken mostly verbatim from https://stackoverflow.com/a/65081431/821285
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID!;
+const isProduction = process.env.NODE_ENV === "production";
+if (isProduction && GA_TRACKING_ID == null) {
+  throw new Error(
+    "GOOGLE_ANALYTICS_TRACKING_ID is not set in a production environment"
+  );
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: URL): void => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+interface GTagEvent {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }: GTagEvent): void => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value,
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,6 +2991,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.8.tgz#43035ab23a06b3bd0b23968c5c4ef000c597ad8a"
+  integrity sha512-xKDygydxruSUNkVbZWjiEbMijz9+xZCLb2yiTiQT88pm5EhIAUhaCo05IZF1HcQc90u4W7cp+7OZNpcJxpyL5g==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"


### PR DESCRIPTION
`NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` is now required in `.env` for production environments.