### PR TITLE
Remove background in mobile

### DIFF
--- a/src/components/CardWithTabs.tsx
+++ b/src/components/CardWithTabs.tsx
@@ -105,6 +105,7 @@ const styles = (theme: Theme) => css`
         flex-direction: row;
         justify-content: center;
         padding: ${theme.spacing(2, 0)};
+        background: none;
       }
 
       button {

--- a/src/components/CardWithTabs.tsx
+++ b/src/components/CardWithTabs.tsx
@@ -105,6 +105,7 @@ const styles = (theme: Theme) => css`
         flex-direction: row;
         justify-content: center;
         padding: ${theme.spacing(2, 0)};
+        padding-bottom: 0;
         background: none;
       }
 


### PR DESCRIPTION
This PR removes the background in the card-with-tabs component in the mobile breakpoint.
The other issue related to this ticket was resolved in T-43