### PR TITLE
Handle when Mastery-/ModuleRecommendations are multiple paragraphs

### DIFF
--- a/src/components/MasteryRecommendation.stories.tsx
+++ b/src/components/MasteryRecommendation.stories.tsx
@@ -16,13 +16,25 @@ export const KaltsitS2 = Template.bind({});
 KaltsitS2.args = {
   level: "3",
   priority: "Low-Medium",
-  analysis:
-    "S2 improves on everything it does with its masteries making it quite noticeable and worthwhile. It can be considered low priority if you already have many other options for operators to effectively lanehold like this skill focuses on. If you’re lacking in said options, then this skill can be considered much more worthwhile to invest into.",
+  children: (
+    <p>
+      S2 improves on everything it does with its masteries making it quite
+      noticeable and worthwhile. It can be considered low priority if you
+      already have many other options for operators to effectively lanehold like
+      this skill focuses on. If you’re lacking in said options, then this skill
+      can be considered much more worthwhile to invest into.
+    </p>
+  ),
 };
 
 export const AkafuyuS2 = Template.bind({});
 AkafuyuS2.args = {
   level: "no",
-  analysis:
-    "S2 ends up being a jack of all trades and master of none with its one more unique aspect, the shield, having no gain from masteries. They are linear with little to no impact making it hard to recommend anything.",
+  children: (
+    <p>
+      S2 ends up being a jack of all trades and master of none with its one more
+      unique aspect, the shield, having no gain from masteries. They are linear
+      with little to no impact making it hard to recommend anything.
+    </p>
+  ),
 };

--- a/src/components/MasteryRecommendation.tsx
+++ b/src/components/MasteryRecommendation.tsx
@@ -4,6 +4,7 @@ import { Theme } from "@mui/material";
 export interface MasteryRecommendationProps {
   level: "no" | "1" | "2" | "3";
   priority?: string;
+  children: React.ReactNode;
 }
 
 const MasteryRecommendation: React.FC<MasteryRecommendationProps> = (props) => {

--- a/src/components/MasteryRecommendation.tsx
+++ b/src/components/MasteryRecommendation.tsx
@@ -4,11 +4,10 @@ import { Theme } from "@mui/material";
 export interface MasteryRecommendationProps {
   level: "no" | "1" | "2" | "3";
   priority?: string;
-  analysis: string;
 }
 
 const MasteryRecommendation: React.FC<MasteryRecommendationProps> = (props) => {
-  const { level, priority, analysis } = props;
+  const { level, priority, children } = props;
   return (
     <section css={styles}>
       <h3>Skill Mastery</h3>
@@ -22,7 +21,7 @@ const MasteryRecommendation: React.FC<MasteryRecommendationProps> = (props) => {
           <dd>{priority ?? "--"}</dd>
         </div>
       </dl>
-      <p dangerouslySetInnerHTML={{ __html: analysis }} />
+      {children}
     </section>
   );
 };

--- a/src/components/ModuleRecommendation.stories.tsx
+++ b/src/components/ModuleRecommendation.stories.tsx
@@ -16,13 +16,32 @@ export const SuzuranM1 = Template.bind({});
 SuzuranM1.args = {
   stage: "1",
   priority: "High",
-  analysis:
-    "Suzuran is very powerful with her S3 encompassing many things, and the module allows you to make use of that skill more often. That alone makes the module a high priority for those making use of Suzuran’s S3. The charging time of S2 can also be decreased if she has enemies in range often. Additional upgrades allowing the talent to also grant ATK aren’t very relevant as supporters, including Suzuran herself, don’t need it to perform well. It improves her offense with S2, or her regen capabilities with S3, with only the latter having rare cases where the additional ATK might make a difference. ",
+  children: (
+    <p>
+      Suzuran is very powerful with her S3 encompassing many things, and the
+      module allows you to make use of that skill more often. That alone makes
+      the module a high priority for those making use of Suzuran’s S3. The
+      charging time of S2 can also be decreased if she has enemies in range
+      often. Additional upgrades allowing the talent to also grant ATK aren’t
+      very relevant as supporters, including Suzuran herself, don’t need it to
+      perform well. It improves her offense with S2, or her regen capabilities
+      with S3, with only the latter having rare cases where the additional ATK
+      might make a difference.
+    </p>
+  ),
 };
 
 export const KafkaM1 = Template.bind({});
 KafkaM1.args = {
   stage: "no",
-  analysis:
-    "The module by itself isn’t too bad to help net additional damage when using her for the burst—however, the main use for Kafka is still the sleep utility from S1. If you’re using Kafka for the instant sleep and instant retreat, this module does nothing and is a wasteful investment. It may still help in situations where you’re using Kafka for fast-redeploy Arts damage, but can be ignored by most players.",
+  children: (
+    <p>
+      The module by itself isn’t too bad to help net additional damage when
+      using her for the burst—however, the main use for Kafka is still the sleep
+      utility from S1. If you’re using Kafka for the instant sleep and instant
+      retreat, this module does nothing and is a wasteful investment. It may
+      still help in situations where you’re using Kafka for fast-redeploy Arts
+      damage, but can be ignored by most players.
+    </p>
+  ),
 };

--- a/src/components/ModuleRecommendation.tsx
+++ b/src/components/ModuleRecommendation.tsx
@@ -4,11 +4,10 @@ import { Theme } from "@mui/material";
 export interface ModuleRecommendationProps {
   stage: string; // apparently 1+ exists so just arbitrary string
   priority?: string;
-  analysis: string;
 }
 
 const ModuleRecommendation: React.FC<ModuleRecommendationProps> = (props) => {
-  const { stage, priority, analysis } = props;
+  const { stage, priority, children } = props;
   return (
     <section css={styles}>
       <dl className="module-recommendation">
@@ -21,7 +20,7 @@ const ModuleRecommendation: React.FC<ModuleRecommendationProps> = (props) => {
           <dd>{priority ?? "--"}</dd>
         </div>
       </dl>
-      <p dangerouslySetInnerHTML={{ __html: analysis }} />
+      {children}
     </section>
   );
 };

--- a/src/components/ModuleRecommendation.tsx
+++ b/src/components/ModuleRecommendation.tsx
@@ -4,6 +4,7 @@ import { Theme } from "@mui/material";
 export interface ModuleRecommendationProps {
   stage: string; // apparently 1+ exists so just arbitrary string
   priority?: string;
+  children: React.ReactNode;
 }
 
 const ModuleRecommendation: React.FC<ModuleRecommendationProps> = (props) => {

--- a/src/components/Modules.stories.tsx
+++ b/src/components/Modules.stories.tsx
@@ -232,13 +232,18 @@ Default.args = {
         damage—Invisibility can be extremely powerful in the right hands. The
         bonus stats don’t matter much as they don’t apply to her summons.
       </p>
-      <ModuleRecommendation
-        stage="1+"
-        priority="Low"
-        analysis={
-          "The module’s new trait doesn’t do much for optimized low op or solo clears with Magallan, but it is a worthwhile upgrade for those wanting to use her in a full team, especially if using S1 to stall. For the upgraded talent, having the option to grant invisibility to Magallan can open up many placement options. It’s something that benefits more careful planning and specialized offensive use, but could also serve as a safety option when Magallan ends up in danger. For low op or solo clears, it is going to be more niche than her Module Y."
-        }
-      />
+      <ModuleRecommendation stage="1+" priority="Low">
+        <p>
+          The module’s new trait doesn’t do much for optimized low op or solo
+          clears with Magallan, but it is a worthwhile upgrade for those wanting
+          to use her in a full team, especially if using S1 to stall. For the
+          upgraded talent, having the option to grant invisibility to Magallan
+          can open up many placement options. It’s something that benefits more
+          careful planning and specialized offensive use, but could also serve
+          as a safety option when Magallan ends up in danger. For low op or solo
+          clears, it is going to be more niche than her Module Y.
+        </p>
+      </ModuleRecommendation>
     </>,
     <>
       <ModuleInfo module={modules[1]} operatorName="char_248_mgllan" key={1} />
@@ -253,13 +258,20 @@ Default.args = {
         at stage 3, the former mattering more in specialized clears while the
         latter can still benefit a more general team.
       </p>
-      <ModuleRecommendation
-        stage="1+"
-        priority="Low"
-        analysis={
-          "While this module doesn’t change Magallan’s playstyle, it’s a great upgrade for those who enjoy using her in low op or solo clears. The decreased cost and additional stored summons lend themselves well towards making Magallan’s low op playstyle easier for less experienced players. The lowered DP cost helps in stages with DP constraints, while the increased number of stored summons means players don’t have to worry as much when losing a summon to enemies instead of recycling it with her skill. Stages 2 and 3 are a good investment for those who enjoy using Magallan and wish to make her more powerful, but come at a steep cost for a playstyle that doesn’t benefit many."
-        }
-      />
+      <ModuleRecommendation stage="1+" priority="Low">
+        <p>
+          While this module doesn’t change Magallan’s playstyle, it’s a great
+          upgrade for those who enjoy using her in low op or solo clears. The
+          decreased cost and additional stored summons lend themselves well
+          towards making Magallan’s low op playstyle easier for less experienced
+          players. The lowered DP cost helps in stages with DP constraints,
+          while the increased number of stored summons means players don’t have
+          to worry as much when losing a summon to enemies instead of recycling
+          it with her skill. Stages 2 and 3 are a good investment for those who
+          enjoy using Magallan and wish to make her more powerful, but come at a
+          steep cost for a playstyle that doesn’t benefit many.
+        </p>
+      </ModuleRecommendation>
     </>,
   ],
 };

--- a/src/pages/operators/[slug].tsx
+++ b/src/pages/operators/[slug].tsx
@@ -95,12 +95,15 @@ const htmlToReact = (
           const props = attributesToProps(domNode.attribs);
           // the first child seems to always be a text node, but then subsequent ones are <p>s.
           // convert text nodes into <p> but feed the rest into domToReact.
-          const children = domNode.children.map((child) => {
+          const children = domNode.children.map((child, i) => {
             if (child.type === "text") {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              return <p>{(child as any).data.trim()}</p>;
+              return <p key={i}>{(child as any).data.trim()}</p>;
             }
-            return domToReact([child]); // needs an array, even if it's a single child.
+            return {
+              ...(domToReact([child]) as JSX.Element), // needs an array, even if it's a single child.
+              key: i, // force a key so React doesn't complain
+            };
           });
           return (
             //@ts-expect-error props will contain level and priority
@@ -110,12 +113,15 @@ const htmlToReact = (
           const props = attributesToProps(domNode.attribs);
           // the first child seems to always be a text node, but then subsequent ones are <p>s.
           // convert text nodes into <p> but feed the rest into domToReact.
-          const children = domNode.children.map((child) => {
+          const children = domNode.children.map((child, i) => {
             if (child.type === "text") {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              return <p>{(child as any).data.trim()}</p>;
+              return <p key={i}>{(child as any).data.trim()}</p>;
             }
-            return domToReact([child]); // needs an array, even if it's a single child.
+            return {
+              ...(domToReact([child]) as JSX.Element), // needs an array, even if it's a single child.
+              key: i, // force a key so React doesn't complain
+            };
           });
           return (
             //@ts-expect-error props will contain priority

--- a/src/pages/operators/[slug].tsx
+++ b/src/pages/operators/[slug].tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Theme, useTheme, css, GlobalStyles } from "@mui/material";
 import { lighten, rgba, transparentize } from "polished";
 import { DateTime } from "luxon";
-import parse, { attributesToProps } from "html-react-parser";
+import parse, { attributesToProps, domToReact } from "html-react-parser";
 import { Element } from "domhandler/lib/node";
 
 import Introduction from "../../components/Introduction";
@@ -93,25 +93,33 @@ const htmlToReact = (
           );
         } else if (domNode.name === "masteryrecommendation") {
           const props = attributesToProps(domNode.attribs);
+          // the first child seems to always be a text node, but then subsequent ones are <p>s.
+          // convert text nodes into <p> but feed the rest into domToReact.
+          const children = domNode.children.map((child) => {
+            if (child.type === "text") {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              return <p>{(child as any).data.trim()}</p>;
+            }
+            return domToReact([child]); // needs an array, even if it's a single child.
+          });
           return (
             //@ts-expect-error props will contain level and priority
-            <MasteryRecommendation
-              {...props}
-              //@ts-expect-error children[0].data should exist on a text node
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              analysis={domNode.children[0].data}
-            />
+            <MasteryRecommendation {...props}>{children}</MasteryRecommendation>
           );
         } else if (domNode.name === "modulerecommendation") {
           const props = attributesToProps(domNode.attribs);
+          // the first child seems to always be a text node, but then subsequent ones are <p>s.
+          // convert text nodes into <p> but feed the rest into domToReact.
+          const children = domNode.children.map((child) => {
+            if (child.type === "text") {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              return <p>{(child as any).data.trim()}</p>;
+            }
+            return domToReact([child]); // needs an array, even if it's a single child.
+          });
           return (
             //@ts-expect-error props will contain priority
-            <ModuleRecommendation
-              {...props}
-              //@ts-expect-error children[0].data should exist on a text node
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              analysis={domNode.children[0].data}
-            />
+            <ModuleRecommendation {...props}>{children}</ModuleRecommendation>
           );
         } else if ((domNode.firstChild as Element)?.name === "img") {
           const contents = (domNode.children as Element[])


### PR DESCRIPTION
The previous method of assuming a single text child of `<MasteryRecommendation>` or `<ModuleRecommendation>` doesn't work when multiple paragraphs are given.