### PR TITLE
Fix Mech-accord branches showing as Phys damage

### DIFF
--- a/src/components/OperatorInfo.tsx
+++ b/src/components/OperatorInfo.tsx
@@ -21,6 +21,8 @@ export interface OperatorInfoProps {
   isLimited?: boolean;
 }
 
+const stripTagsRegex = /<(\/|([@$a-z.]+))>/g;
+
 const getAttackType = (
   operatorClass: string,
   subProfessionId: string,
@@ -28,8 +30,11 @@ const getAttackType = (
 ): "Physical" | "Arts" | "Healing" | "None" => {
   if (subProfessionId === "bard") return "None";
   if (operatorClass === "Medic") return "Healing";
-  return description.toLowerCase().includes("arts damage") ||
-    description.includes("法术伤害")
+  const descriptionNoTags = description
+    .replace(stripTagsRegex, "")
+    .toLowerCase();
+  return descriptionNoTags.includes("arts damage") ||
+    descriptionNoTags.includes("法术伤害")
     ? "Arts"
     : "Physical";
 };


### PR DESCRIPTION
The Mech-accord branch description is:
```text
'Controls a <@ba.kw>Drone</> to deal <@ba.kw>Arts</> damage to an enemy; When the Drone continuously attacks the same enemy, its damage will increase (up to 110% of the operator's ATK)'
```
The `<@ba.kw>Arts</>` portion caused the check for `arts damage` to fail, so we need to strip the formatting tags before doing a string search.