### PR TITLE
Replace lighten fn with tint

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -7,7 +7,7 @@ import "wicg-inert";
 
 import SanityGoneLogo from "./components/SanityGoneLogo";
 import MobileMenuIcon from "./components/icons/MobileMenuIcon";
-import { lighten, rgba, transparentize } from "polished";
+import { tint, rgba, transparentize } from "polished";
 import MobileMenu from "./components/MobileMenu";
 import SearchBar from "./components/SearchBar";
 import WeirdDeathSphere from "./components/WeirdDeathSphere";
@@ -536,11 +536,11 @@ const styles =
               padding: ${theme.spacing(0, 0.5)};
               border-radius: ${theme.spacing(0.25)};
 
-              color: ${rgba(lighten(0.27, theme.palette.blue.main), 0.66)};
+              color: ${rgba(tint(0.27, theme.palette.blue.main), 0.66)};
               background-color: ${rgba(theme.palette.blue.main, 0.08)};
 
               &:hover {
-                color: ${lighten(0.27, theme.palette.blue.main)};
+                color: ${tint(0.27, theme.palette.blue.main)};
                 background-color: ${rgba(theme.palette.blue.main, 0.4)};
               }
             }
@@ -676,11 +676,11 @@ const styles =
           padding: ${theme.spacing(0, 0.5)};
           border-radius: ${theme.spacing(0.25)};
           transition: all 50ms ease-out;
-          color: ${rgba(lighten(0.27, theme.palette.blue.main), 0.66)};
+          color: ${rgba(tint(0.27, theme.palette.blue.main), 0.66)};
           background-color: ${rgba(theme.palette.blue.main, 0.08)};
 
           &:hover {
-            color: ${lighten(0.27, theme.palette.blue.main)};
+            color: ${tint(0.27, theme.palette.blue.main)};
             background-color: ${rgba(theme.palette.blue.main, 0.4)};
           }
         }

--- a/src/pages/operators/[slug].tsx
+++ b/src/pages/operators/[slug].tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Theme, useTheme, css, GlobalStyles } from "@mui/material";
-import { lighten, rgba, transparentize } from "polished";
+import { tint, rgba, transparentize } from "polished";
 import { DateTime } from "luxon";
 import parse, { attributesToProps, domToReact } from "html-react-parser";
 import { Element } from "domhandler/lib/node";
@@ -683,7 +683,7 @@ const globalOverrideStyles =
           ${transparentize(0.67, theme.palette.midtoneBrighter.main)};
 
         h2 {
-          color: ${lighten(0.27, accentColor)} !important;
+          color: ${tint(0.27, accentColor)} !important;
         }
       }
 
@@ -741,11 +741,11 @@ const globalOverrideStyles =
             }
           }
           .breadcrumb > a {
-            color: ${rgba(lighten(0.27, accentColor), 0.66)};
+            color: ${rgba(tint(0.27, accentColor), 0.66)};
             background-color: ${rgba(accentColor, 0.08)};
 
             &:hover {
-              color: ${lighten(0.27, accentColor)};
+              color: ${tint(0.27, accentColor)};
               background-color: ${rgba(accentColor, 0.4)};
             }
           }
@@ -849,8 +849,8 @@ const styles = (accentColor: string) => (theme: Theme) =>
             ${transparentize(0.9, accentColor)},
             ${transparentize(0.8, accentColor)}
           );
-          color: ${lighten(0.27, accentColor)};
-          border-right: 3px solid ${lighten(0.27, accentColor)};
+          color: ${tint(0.27, accentColor)};
+          border-right: 3px solid ${tint(0.27, accentColor)};
           font-weight: ${theme.typography.navigationLinkBold.fontWeight};
         }
 
@@ -912,11 +912,11 @@ const styles = (accentColor: string) => (theme: Theme) =>
         a {
           margin-right: ${theme.spacing(1)};
 
-          color: ${rgba(lighten(0.27, accentColor), 0.66)};
+          color: ${rgba(tint(0.27, accentColor), 0.66)};
           background-color: ${rgba(accentColor, 0.08)};
 
           &:hover {
-            color: ${lighten(0.27, accentColor)};
+            color: ${tint(0.27, accentColor)};
             background-color: ${rgba(accentColor, 0.4)};
           }
         }

--- a/src/pages/operators/index.tsx
+++ b/src/pages/operators/index.tsx
@@ -12,7 +12,7 @@ import {
   useTheme,
 } from "@mui/material";
 import slugify from "@sindresorhus/slugify";
-import { lighten, rgba } from "polished";
+import { tint, rgba } from "polished";
 import { MdArrowForwardIos } from "react-icons/md";
 
 import Layout from "../../Layout";
@@ -764,7 +764,7 @@ const styles = (theme: Theme) => css`
         font-weight: 500;
 
         &:hover {
-          color: ${lighten(0.27, theme.palette.white.main)};
+          color: ${tint(0.27, theme.palette.white.main)};
           background-color: ${rgba(theme.palette.white.main, 0.4)};
         }
       }
@@ -795,7 +795,7 @@ const styles = (theme: Theme) => css`
       }
 
       &:hover {
-        color: ${lighten(0.27, theme.palette.white.main)};
+        color: ${tint(0.27, theme.palette.white.main)};
         background-color: ${rgba(theme.palette.white.main, 0.4)};
       }
 


### PR DESCRIPTION
Lighten will result in #fff for sufficiently bright colors while tint does not.