### PR TITLE
Completely disable React rerendering of operator cards

### DIFF
--- a/src/components/OperatorList.tsx
+++ b/src/components/OperatorList.tsx
@@ -78,7 +78,7 @@ const OperatorList: React.VFC<Props> = React.memo((props) => {
           li.style.display = "none";
         }
       });
-    if (numVisible > 1) {
+    if (numVisible > 0) {
       noResultsRef.current.style.display = "none";
     } else {
       noResultsRef.current.style.removeProperty("display");

--- a/src/components/OperatorList.tsx
+++ b/src/components/OperatorList.tsx
@@ -83,7 +83,6 @@ const OperatorList: React.VFC<Props> = React.memo((props) => {
     } else {
       noResultsRef.current.style.removeProperty("display");
     }
-    console.log(numVisible);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterSettings]);
 

--- a/src/pages/operators/index.tsx
+++ b/src/pages/operators/index.tsx
@@ -306,24 +306,13 @@ const Operators: React.VFC<Props> = (props) => {
       ? subProfessionIdToSubclass(selectedSubProfessionId)
       : null;
 
-  const operatorsToShow = useMemo(
-    () =>
-      allOperators.filter((op) => {
-        return (
-          (!showOnlyGuideAvailable || operatorsWithGuides[op.name] != null) &&
-          (selectedProfession == null ||
-            op.profession === selectedProfession) &&
-          (selectedSubProfessionId == null ||
-            op.subProfessionId === selectedSubProfessionId)
-        );
-      }),
-    [
-      allOperators,
-      operatorsWithGuides,
+  const filterSettings = useMemo(
+    () => ({
+      showOnlyGuideAvailable,
       selectedProfession,
       selectedSubProfessionId,
-      showOnlyGuideAvailable,
-    ]
+    }),
+    [selectedProfession, selectedSubProfessionId, showOnlyGuideAvailable]
   );
 
   const sortAndFilterOptions = (
@@ -603,13 +592,10 @@ const Operators: React.VFC<Props> = (props) => {
             <h2>Operators</h2>
             <OperatorList
               operators={allOperators}
-              operatorsToShow={operatorsToShow}
+              filterSettings={filterSettings}
               operatorsWithGuides={operatorsWithGuides}
               onSubclassFilter={handleSubclassFilter}
             />
-            {operatorsToShow.length === 0 && (
-              <div className="no-results">No Results</div>
-            )}
           </section>
         </div>
       </main>


### PR DESCRIPTION
Instead we render them once inside React, then only use DOM mutations to change their visibility after that.