### PR TITLE
Remove markdown from og:description

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/node": "^17.0.18",
     "@types/react": "17.0.47",
     "@types/react-dom": "17.0.17",
+    "@types/remove-markdown": "^0.3.1",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",
     "eslint": "^8.9.0",
@@ -76,6 +77,7 @@
     "next-sitemap": "^2.5.4",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "prettier": "^2.3.2",
+    "remove-markdown": "^0.5.0",
     "ts-node": "^10.5.0",
     "typescript": "^4.8.0"
   },

--- a/src/pages/operators/[slug].tsx
+++ b/src/pages/operators/[slug].tsx
@@ -3,6 +3,7 @@ import { Box, Theme, useTheme, css, GlobalStyles } from "@mui/material";
 import { tint, rgba, transparentize } from "polished";
 import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
+import removeMarkdown from "remove-markdown";
 
 import Introduction from "../../components/Introduction";
 import CharacterStats from "../../components/CharacterStats";
@@ -181,7 +182,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     ogDescription:
       operatorAnalysis.customByline ??
       `${
-        operatorAnalysis.introduction
+        removeMarkdown(operatorAnalysis.introduction)
           .replace(/<\/?[A-za-z-]*>/g, "")
           .split(/(\.)\s*/)[0]
       }.`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,6 +3251,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/remove-markdown@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/remove-markdown/-/remove-markdown-0.3.1.tgz#82bc3664c313f50f7c77f1bb59935f567689dc63"
+  integrity sha512-JpJNEJEsmmltyL2LdE8KRjJ0L2ad5vgLibqNj85clohT9AyTrfN6jvHxStPshDkmtcL/ShFu0p2tbY7DBS1mqQ==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -10977,6 +10982,11 @@ remark-squeeze-paragraphs@4.0.0:
   integrity sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
+
+remove-markdown@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.5.0.tgz#a596264bbd60b9ceab2e2ae86e5789eee91aee32"
+  integrity sha512-x917M80K97K5IN1L8lUvFehsfhR8cYjGQ/yAMRI9E7JIKivtl5Emo5iD13DhMr+VojzMCiYk8V2byNPwT/oapg==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Currently og:description contains Markdown formatting, so e.g. a Discord embed has

> Pallas is an __Instructor Guard__ that stands out due to her uncharacteristically good DPS potential for the branch.

(note the underscores)