### PR TITLE
Replace MUI InputBase with plain <input>

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { InputBase, Theme } from "@mui/material";
+import { Theme } from "@mui/material";
 import FlexSearch from "flexsearch";
 import {
   operatorAvatar,
@@ -100,7 +100,7 @@ const SearchBar: React.VFC<SearchBarProps> = (props) => {
     >
       <div className={`search-bar ${query && isFocused ? " menu-down" : ""}`}>
         <SearchIcon className="search-icon" />
-        <InputBase
+        <input
           className="search-input"
           placeholder={placeholder}
           onChange={(e) => {
@@ -280,10 +280,16 @@ const styles = (theme: Theme) => css`
     }
 
     .search-input {
+      background: none;
+      border: none;
       flex: 1 1 0;
       color: ${theme.palette.white.main};
       margin: ${theme.spacing(1, 0)};
       font-size: ${theme.typography.body2.fontSize}px;
+
+      &:focus {
+        outline: none;
+      }
 
       & > input::placeholder {
         opacity: 0.66;


### PR DESCRIPTION
Just needed to remove the default input's background and border.

Focus styles are also removed because we apply a focus style to the entire search box when the input has focus.

Close T-188.